### PR TITLE
Using correct dest config property.

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -34,7 +34,7 @@ module.exports = function(gulp, config, browserSync) {
       .pipe(sourceMaps.write(config.build.sourceMapPath))
       .pipe(gulp.dest(config.styles.dest))
       .pipe(browserSync.stream({match: '**/*.css'}))
-      .pipe(gulpif(config.build.rev, rev.manifest({cwd: config.statics.dest, merge: true})))
-      .pipe(gulpif(config.build.rev, gulp.dest(config.statics.dest)));
+      .pipe(gulpif(config.build.rev, rev.manifest({cwd: config.styles.dest, merge: true})))
+      .pipe(gulpif(config.build.rev, gulp.dest(config.styles.dest)));
   });
 };

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -65,8 +65,8 @@ module.exports = function(gulp, config) {
       .pipe(gulpif(config.build.rev, rev()))
       .pipe(sourceMaps.write(config.build.sourceMapPath))
       .pipe(gulp.dest(config.scripts.dest))
-      .pipe(gulpif(config.build.rev, rev.manifest({cwd: config.statics.dest, merge: true})))
-      .pipe(gulpif(config.build.rev, gulp.dest(config.statics.dest)));
+      .pipe(gulpif(config.build.rev, rev.manifest({cwd: config.scripts.dest, merge: true})))
+      .pipe(gulpif(config.build.rev, gulp.dest(config.scripts.dest)));
   });
 };
 


### PR DESCRIPTION
When starting with gulp-modular, I started with the styles first. But the `sass` task uses the wrong `dest` config property.
