### PR TITLE
Feature: markdown to html processing

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -24,6 +24,7 @@ Open the file and customize the tasks to match your specific project requirement
     * [statics](#statics)
     * [images](#images)
     * [fonts](#fonts)
+    * [markdown](#markdown)
     * [scripts](#scripts)
     * [styles](#styles)
 * [Serving](#serving)
@@ -109,6 +110,17 @@ Optional task fonts collects specified fonts and stores them in a dedicated dist
 
 * **src** `='app/fonts/**/*.{otf,eot,svg,ttf,woff}'` glob that points to all fonts
 * **dest** `='dist/fonts/'` destination of the font files
+
+### markdown
+Optional task markdown converts markdown to html and applies styles. Basic setup to generate a static site.
+
+* **src** `='src/content/**/*.md'` glob that points to all content files
+* **dest** `='dist/'` destination of the generated html files
+* **layouts** `='{}'` adds layout engine configuration
+    * **src** `='src/layouts'` path where the layouts can be found
+    * **partials** `='src/layouts/partials'` path where partial layouts can be found
+    * **engine** `='handlebars'` any layout engine supported by consolidate.js
+    * **layout** `='default.hbs'` default layout to apply when none is specified in the markdown frontmatter
 
 ### scripts
 Optional task scripts collects scripts, runs several transformations, concatenates everything and stores them in a dedicated distribution folder.

--- a/defaultConfiguration.js
+++ b/defaultConfiguration.js
@@ -47,6 +47,16 @@ module.exports = {
     src: 'app/fonts/**/*.{otf,eot,svg,ttf,woff}',
     dest: 'dist/fonts/'
   },
+  markdown: {
+    src: 'src/content/**/*.md',
+    dest: 'dist/',
+    layouts: {
+      src: 'src/layouts/',
+      partials: 'src/layouts/partials/',
+      engine: 'handlebars',
+      layout: 'default.hbs'
+    }
+  },
   scripts: {
     src: ['app/components/**/*.js', '!app/components/**/*.spec.js'],
     dest: 'dist/js/',

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ module.exports = function(gulp, userConfig) {
     require('./tasks/jshint')(gulp, config);
   }
 
+  if (config.markdown) {
+    require('./tasks/markdown')(gulp, config);
+  }
+
   if (config.mavenDeploy) {
     require('./tasks/mavenDeploy')(gulp, config);
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "connect-history-api-fallback": "^1.1.0",
     "del": "^2.2.0",
     "extend": "^3.0.0",
+    "fs-readdir-recursive": "^1.0.0",
     "gulp": "^3.9.0",
     "gulp-angular-filesort": "^1.1.1",
     "gulp-autoprefixer": "^3.1.0",
@@ -43,12 +44,15 @@
     "gulp-concat": "^2.5.2",
     "gulp-debug": "^2.0.1",
     "gulp-flatten": "^0.3.1",
+    "gulp-front-matter": "^1.3.0",
     "gulp-gh-pages": "^0.5.2",
     "gulp-if": "^2.0.0",
     "gulp-iife": "^0.3.0",
     "gulp-imagemin": "^3.0.3",
     "gulp-inject": "^4.1.0",
     "gulp-jshint": "^2.0.0",
+    "gulp-layout": "0.0.4",
+    "gulp-markdown": "^1.2.0",
     "gulp-maven-deploy": "^1.0.1",
     "gulp-minify-html": "^1.0.3",
     "gulp-minify-inline": "^0.2.0",
@@ -70,5 +74,6 @@
     "merge-stream": "^1.0.0",
     "node-sass-globbing": "^0.0.23",
     "underscore": "^1.8.3"
-  }
+  },
+  "devDependencies": {}
 }

--- a/sample-gulpfile.js
+++ b/sample-gulpfile.js
@@ -79,7 +79,18 @@ var config = {
   //  dest: 'dist/fonts/' // destination of the font files
   //},
 
-  //// task [`scripts`] collects scripts, runs several transformations and concatenates everything
+  // // task [`markdown`] converts markdown to html and applies styles.
+  // markdown: {
+  //   src: 'src/content/**/*.md', // glob that points to all content files
+  //   dest: 'dist/', // destination of the generated html files
+  //   layouts: {
+  //     src: 'src/layouts', // path where partial layouts can be found
+  //     partials: 'src/layouts/partials', // path where partial layouts can be found
+  //     engine: 'handlebars', // any layout engine supported by consolidate.js
+  //     layout: 'default.hbs' // default layout to apply when none is specified in the markdown frontmatter
+  // },
+
+//// task [`scripts`] collects scripts, runs several transformations and concatenates everything
   //scripts: {
   //  src: ['app/components/**/*.js', '!app/components/**/*.spec.js'], // glob that points to all scripts (except tests)
   //  dest: 'dist/js/', // destination of the concat file `scripts.js` (and associated sourcemaps file)

--- a/tasks/markdown.js
+++ b/tasks/markdown.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var markdown = require('gulp-markdown');
+var frontMatter = require('gulp-front-matter');
+var layout = require('gulp-layout');
+
+var path = require('path');
+var read = require('fs-readdir-recursive');
+
+var cwd = process.cwd();
+
+/**
+ * Helper for reading a folder with partials, returns a `partials` object that
+ * can be consumed by consolidate.
+ *
+ * @param {String} partialsPath
+ * @param {String} layoutsPath
+ * @param {String} sourcePath
+ * @return {Object}
+ */
+function readPartials(partialsPath, layoutsPath, sourcePath) {
+  var partialsAbs = path.isAbsolute(partialsPath) ? partialsPath : path.join(sourcePath, partialsPath);
+  var layoutsAbs = path.isAbsolute(layoutsPath) ? layoutsPath : path.join(sourcePath, layoutsPath);
+  var files = read(partialsAbs);
+  var partials = {};
+
+  // Return early if there are no partials
+  if (files.length === 0) {
+    return partials;
+  }
+
+  // Read and process all partials
+  for (var i = 0; i < files.length; i++) {
+    var fileInfo = path.parse(files[i]);
+    var name = path.join(fileInfo.dir, fileInfo.name);
+    var partialAbs = path.join(partialsAbs, name);
+    var partialPath = path.relative(layoutsAbs, partialAbs);
+
+    var partialKey = name.replace(/\\/g, '/');
+    partials[partialKey] = partialPath;
+  }
+
+  return partials;
+}
+
+module.exports = function (gulp, config) {
+  gulp.task('markdown', function () {
+    var partials = readPartials(config.markdown.layout.partials, config.markdown.layout.src, cwd);
+
+    return gulp.src(config.markdown.src)
+      .pipe(frontMatter())
+      .pipe(markdown())
+      .pipe(layout(function (file) {
+        var base_options = Object.assign({}, config.markdown.layout);
+        var base_and_frontmatter_options = Object.assign(base_options, file.frontMatter);
+        base_and_frontmatter_options.partials = Object.assign({}, partials);
+
+        if (file.frontMatter.layout) {
+          base_and_frontmatter_options.layout = path.join(base_options.src, file.frontMatter.layout);
+        } else {
+          base_and_frontmatter_options.layout = path.join(base_options.src, base_options.layout);
+        }
+        return base_and_frontmatter_options
+      }))
+      .pipe(gulp.dest(config.markdown.dest))
+  });
+};


### PR DESCRIPTION
Support to process markdown files, strip the frontmatter, convert to html and apply a layout.

Uses:
- gulp-frontmatter
- gulp-markdown
- gulp-layout
